### PR TITLE
Clean up limit/quota test pods

### DIFF
--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -223,11 +223,12 @@ This lab creates namespaces that reflect a representative example of an organiza
     kubectl describe ns dev
     ```
 
-5. Clean up quotas
+5. Clean up limits, quotas, pods
 
     ```
     kubectl delete -f namespace-limitranges.yaml
     kubectl delete -f namespace-quotas.yaml
+    kubectl delete po nginx-limittest nginx-quotatest -n dev
 
     kubectl describe ns dev
     kubectl describe ns uat


### PR DESCRIPTION
This PR addresses issue #49 by adding an additional step to clean up the two pods used for testing limits and quotas.
