### PR TITLE
Update service-tracker-ingress.yaml

### DIFF
--- a/labs/networking/ingress/service-tracker-ingress.yaml
+++ b/labs/networking/ingress/service-tracker-ingress.yaml
@@ -14,7 +14,7 @@ spec:
   - host: brian13270.eastus.cloudapp.azure.com
     http:
       paths:
-      - path: /ui
+      - path: /
         backend:
           serviceName: service-tracker-ui
           servicePort: 8080


### PR DESCRIPTION
Fix for service tracker ui not loading in browser because of the /ui path as part of the networking ingress lab.