### PR TITLE
Minor updates to  Securing Tiller Lab

### DIFF
--- a/labs/networking/network-policy/README.md
+++ b/labs/networking/network-policy/README.md
@@ -27,6 +27,8 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
    ```bash
    cd ~/kubernetes-hackfest
+
+   kubectl apply -f ./labs/networking/network-policy/kube-router-rbac.yaml
    kubectl apply -f ./labs/networking/network-policy/kube-router.yaml
    kubectl get daemonset -n kube-system -l k8s-app=kube-router
    ```

--- a/labs/networking/network-policy/README.md
+++ b/labs/networking/network-policy/README.md
@@ -35,7 +35,7 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
     ```bash
     kubectl apply -f ./labs/networking/network-policy/deny-all.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     ```
 
 3. Test out the Application by going to the Dashboard and clicking on the Refresh Data button for one of the APIs. You should see that the Refresh is taking an extra long time and eventually comes back with an error. This is becuase you have denied all Ingress to Pods, which means all traffic into the Cluster.
@@ -69,7 +69,7 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
     ```bash
     # Apply the Allow Network Policy
     kubectl apply -f ./labs/networking/network-policy/allow-default-namespace.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Let's Test the nslookup again
     kubectl exec -it $(kubectl get pod -n hackfest -l "app=quakes-api" -o jsonpath='{.items[0].metadata.name}') -n hackfest -- /bin/sh
     # Once inside the Pod try to do a nslookup on the flights API
@@ -94,10 +94,10 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
     ```bash
     # Delete Previous Network Allow Policy
     kubectl delete -f ./labs/networking/network-policy/allow-default-namespace.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Apply the Allow Network Policy
     kubectl apply -f ./labs/networking/network-policy/allow-default-namespace-with-egress.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Let's Test the nslookup again
     kubectl exec -it $(kubectl get pod -n hackfest -l "app=quakes-api" -o jsonpath='{.items[0].metadata.name}') -n hackfest -- /bin/sh
     # Once inside the Pod try to do a nslookup on the flights API
@@ -126,8 +126,8 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
     ```bash
     # Cleanup Network Policies
-    kubectl delete networkpolicy --all
-    kubectl get networkpolicy
+    kubectl delete networkpolicy --all -n hackfest
+    kubectl get networkpolicy -n hackfest
     ```
 
 ## Troubleshooting / Debugging

--- a/labs/networking/network-policy/kube-router-rbac.yaml
+++ b/labs/networking/network-policy/kube-router-rbac.yaml
@@ -13,6 +13,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-  - kind: ServiceAccount
+  - kind: User
     name: nodeclient
     namespace: kube-system

--- a/labs/security/secure-tiller/README.md
+++ b/labs/security/secure-tiller/README.md
@@ -7,6 +7,9 @@ This lab walks through how to secure tiller in a single namespace to restrict ac
 1. Create Helm/Tiller for **dev** Namespace
 
     ```bash
+    # Move to the lab directory
+    cd ~/kubernetes-hackfest/labs/security/secure-tiller/
+
     # Create kubeconfig file for tiller Service Account (Useful for DevOps)
     chmod a+x tiller-namespace-setup.sh
     ./tiller-namespace-setup.sh tiller dev

--- a/labs/security/secure-tiller/tiller-namespace-setup.sh
+++ b/labs/security/secure-tiller/tiller-namespace-setup.sh
@@ -32,13 +32,13 @@ get_secret_name_from_service_account() {
 
 extract_ca_crt_from_secret() {
     echo -e -n "\\nExtracting ca.crt from secret..."
-    kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["ca.crt"]' | base64 -D > "${TARGET_FOLDER}/ca.crt"
+    kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["ca.crt"]' | base64 -d > "${TARGET_FOLDER}/ca.crt"
     printf "done"
 }
 
 get_user_token_from_secret() {
     echo -e -n "\\nGetting user token from secret..."
-    USER_TOKEN=$(kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["token"]' | base64 -D)
+    USER_TOKEN=$(kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["token"]' | base64 -d)
     printf "done"
 }
 


### PR DESCRIPTION
Added a line to instruct users to change directory into the lab folder. 

Updated the tiller-namespace-setup.sh script to use -d instead of -D for base64, because -D isnt supported in cloud shell. 
fixes #109 