### PR TITLE
Minor changes to address issues in Tiller lab (fixing previous PR)

### DIFF
--- a/labs/security/secure-tiller/README.md
+++ b/labs/security/secure-tiller/README.md
@@ -7,6 +7,9 @@ This lab walks through how to secure tiller in a single namespace to restrict ac
 1. Create Helm/Tiller for **dev** Namespace
 
     ```bash
+    # Move to the lab directory
+    cd ~/kubernetes-hackfest/labs/security/secure-tiller/
+
     # Create kubeconfig file for tiller Service Account (Useful for DevOps)
     chmod a+x tiller-namespace-setup.sh
     ./tiller-namespace-setup.sh tiller dev

--- a/labs/security/secure-tiller/tiller-namespace-setup.sh
+++ b/labs/security/secure-tiller/tiller-namespace-setup.sh
@@ -32,13 +32,13 @@ get_secret_name_from_service_account() {
 
 extract_ca_crt_from_secret() {
     echo -e -n "\\nExtracting ca.crt from secret..."
-    kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["ca.crt"]' | base64 -D > "${TARGET_FOLDER}/ca.crt"
+    kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["ca.crt"]' | base64 -d > "${TARGET_FOLDER}/ca.crt"
     printf "done"
 }
 
 get_user_token_from_secret() {
     echo -e -n "\\nGetting user token from secret..."
-    USER_TOKEN=$(kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["token"]' | base64 -D)
+    USER_TOKEN=$(kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o json | jq -r '.data["token"]' | base64 -d)
     printf "done"
 }
 


### PR DESCRIPTION
Added a line to instruct users to change directory into the lab folder.

Updated the tiller-namespace-setup.sh script to use -d instead of -D for base64, because -D isnt supported in cloud shell.
fixes #109 