### PR TITLE
Updated policy lab to address RBAC and Namespace issues

### DIFF
--- a/labs/networking/network-policy/README.md
+++ b/labs/networking/network-policy/README.md
@@ -27,6 +27,8 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
    ```bash
    cd ~/kubernetes-hackfest
+
+   kubectl apply -f ./labs/networking/network-policy/kube-router-rbac.yaml
    kubectl apply -f ./labs/networking/network-policy/kube-router.yaml
    kubectl get daemonset -n kube-system -l k8s-app=kube-router
    ```

--- a/labs/networking/network-policy/README.md
+++ b/labs/networking/network-policy/README.md
@@ -35,7 +35,7 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
     ```bash
     kubectl apply -f ./labs/networking/network-policy/deny-all.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     ```
 
 3. Test out the Application by going to the Dashboard and clicking on the Refresh Data button for one of the APIs. You should see that the Refresh is taking an extra long time and eventually comes back with an error. This is becuase you have denied all Ingress to Pods, which means all traffic into the Cluster.
@@ -69,7 +69,7 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
     ```bash
     # Apply the Allow Network Policy
     kubectl apply -f ./labs/networking/network-policy/allow-default-namespace.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Let's Test the nslookup again
     kubectl exec -it $(kubectl get pod -n hackfest -l "app=quakes-api" -o jsonpath='{.items[0].metadata.name}') -n hackfest -- /bin/sh
     # Once inside the Pod try to do a nslookup on the flights API
@@ -94,10 +94,10 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
     ```bash
     # Delete Previous Network Allow Policy
     kubectl delete -f ./labs/networking/network-policy/allow-default-namespace.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Apply the Allow Network Policy
     kubectl apply -f ./labs/networking/network-policy/allow-default-namespace-with-egress.yaml
-    kubectl get networkpolicy
+    kubectl get networkpolicy -n hackfest
     # Let's Test the nslookup again
     kubectl exec -it $(kubectl get pod -n hackfest -l "app=quakes-api" -o jsonpath='{.items[0].metadata.name}') -n hackfest -- /bin/sh
     # Once inside the Pod try to do a nslookup on the flights API
@@ -126,8 +126,8 @@ In this lab we will use Kube-Router for Network Policy Management. Kube-Router w
 
     ```bash
     # Cleanup Network Policies
-    kubectl delete networkpolicy --all
-    kubectl get networkpolicy
+    kubectl delete networkpolicy --all -n hackfest
+    kubectl get networkpolicy -n hackfest
     ```
 
 ## Troubleshooting / Debugging

--- a/labs/networking/network-policy/kube-router-rbac.yaml
+++ b/labs/networking/network-policy/kube-router-rbac.yaml
@@ -13,6 +13,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-  - kind: ServiceAccount
+  - kind: User
     name: nodeclient
     namespace: kube-system


### PR DESCRIPTION
Several fixes:
1) The Hackfest namespaces is used in the yaml files, but was excluded from serveral kubectl commands.
2) The lab now assumes RBAC, but the rbac yaml was not applied in the lab steps.
3) The kube-router-rbac.yaml file was using ServiceAccount, but kuberouter was expecting a User.