### PR TITLE
Switch from absolute paths to relative paths

### DIFF
--- a/labs/aci/README.md
+++ b/labs/aci/README.md
@@ -16,7 +16,7 @@ This lab has 2 components. First we will use Azure Container Instances to deploy
 1. Create container image for batch processing
 
     ```bash
-    az acr build -t hackfest/data-updater:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/data-updater
+    az acr build -t hackfest/data-updater:1.0 -r $ACRNAME --no-logs app/data-updater
     ```
 
 2. Configure ACR credentials to be stored in Azure Key Vault
@@ -236,11 +236,11 @@ For this lab, we are creating a new AKS cluster. Depending on your quota, you ma
     c. Install each chart as below:
 
     ```bash
-    helm upgrade --install data-api ~/kubernetes-hackfest/charts/data-api --namespace hackfest
-    helm upgrade --install quakes-api ~/kubernetes-hackfest/charts/quakes-api --namespace hackfest
-    helm upgrade --install weather-api ~/kubernetes-hackfest/charts/weather-api --namespace hackfest
-    helm upgrade --install flights-api ~/kubernetes-hackfest/charts/flights-api --namespace hackfest
-    helm upgrade --install service-tracker-ui ~/kubernetes-hackfest/charts/service-tracker-ui --namespace hackfest
+    helm upgrade --install data-api charts/data-api --namespace hackfest
+    helm upgrade --install quakes-api charts/quakes-api --namespace hackfest
+    helm upgrade --install weather-api charts/weather-api --namespace hackfest
+    helm upgrade --install flights-api charts/flights-api --namespace hackfest
+    helm upgrade --install service-tracker-ui charts/service-tracker-ui --namespace hackfest
     ```
 
     d. Validate that the service-tracker-ui is up and running. Eg - browse to http://your-public-ip:8080 
@@ -257,7 +257,7 @@ For this lab, we are creating a new AKS cluster. Depending on your quota, you ma
 
     Create the new deployment
     ```bash
-    kubectl apply -f ~/kubernetes-hackfest/labs/aci/service-tracker-ui.yaml -n hackfest
+    kubectl apply -f labs/aci/service-tracker-ui.yaml -n hackfest
     ```
 
     Validate that the pod is running on the virtual node and verify that you have an ACI in the Azure portal

--- a/labs/best-practices/appdev/README.md
+++ b/labs/best-practices/appdev/README.md
@@ -99,7 +99,7 @@ This lab has a number of exercises in no particular order:
     * Build the new image and try it out
 
         ```bash
-        az acr build -t hackfest/flights-api:multistage -r $ACRNAME --no-logs ~/kubernetes-hackfest/labs/best-practices/appdev/flights-api
+        az acr build -t hackfest/flights-api:multistage -r $ACRNAME --no-logs labs/best-practices/appdev/flights-api
         ```
     
     * Check out the image scanning lab in the [Best Practices for Cluster Operators](../operators/README.md) section.
@@ -133,7 +133,7 @@ In this lab, we will add code to our `data-api` service to provide a health chec
 * Using this source code, create a new container image
 
     ```bash
-    az acr build -t hackfest/data-api:2.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/labs/best-practices/appdev/data-api
+    az acr build -t hackfest/data-api:2.0 -r $ACRNAME --no-logs labs/best-practices/appdev/data-api
     ```
 
 * Delete the existing `data-api` deploy
@@ -160,7 +160,7 @@ In this lab, we will add code to our `data-api` service to provide a health chec
 
 * Deploy the updated `data-api`
     ```bash
-    kubectl apply -n hackfest -f ~/kubernetes-hackfest/labs/best-practices/appdev/data-api-probes.yaml
+    kubectl apply -n hackfest -f labs/best-practices/appdev/data-api-probes.yaml
     ```
 
 * Validate the health check endpoint is working
@@ -217,7 +217,7 @@ In this lab, we will update our application to handle failures gracefully and th
 * Using this source code, create a new container image
 
     ```bash
-    az acr build -t hackfest/data-api:error-handling -r $ACRNAME --no-logs ~/kubernetes-hackfest/labs/best-practices/appdev/data-api
+    az acr build -t hackfest/data-api:error-handling -r $ACRNAME --no-logs labs/best-practices/appdev/data-api
     ```
 
 * Delete the existing `data-api` deploy
@@ -235,7 +235,7 @@ In this lab, we will update our application to handle failures gracefully and th
 
 * Deploy the updated `data-api`
     ```bash
-    kubectl apply -n hackfest -f ~/kubernetes-hackfest/labs/best-practices/appdev/data-api-error.yaml
+    kubectl apply -n hackfest -f labs/best-practices/appdev/data-api-error.yaml
     ```
 
 * The pod should fail to start. You should be able to find the exception logged in App Insights (it can take a few minutes)
@@ -276,7 +276,7 @@ In this lab, we will update our application to handle failures gracefully and th
 
 * Deploy the updated `quakes-api`
     ```bash
-    kubectl apply -n hackfest -f ~/kubernetes-hackfest/labs/best-practices/appdev/quakes-api.yaml
+    kubectl apply -n hackfest -f labs/best-practices/appdev/quakes-api.yaml
     ```
 
 * Scale the deployment. You should see some pods go to `Pending` state.
@@ -310,7 +310,7 @@ In this lab, we will ensure our Pods cannot run as root and other important secu
     
 * Deploy the updated app
     ```bash
-    kubectl apply -n hackfest -f ~/kubernetes-hackfest/labs/best-practices/appdev/weather-api.yaml
+    kubectl apply -n hackfest -f labs/best-practices/appdev/weather-api.yaml
     ```
 
 * Exec into pod and compare to one of the other API pods. Note that the weather pod is not running as root. 

--- a/labs/best-practices/operators/README.md
+++ b/labs/best-practices/operators/README.md
@@ -196,13 +196,13 @@ We can use "pod disruption budgets" to make sure a minimum number of pods are av
     ```
 
     ```bash
-    kubectl apply -f ~/kubernetes-hackfest/labs/best-practices/operators/pod-disruption-budget.yaml -n hackfest
+    kubectl apply -f labs/best-practices/operators/pod-disruption-budget.yaml -n hackfest
     ```
 
 * Create a new version of the service-tracker-ui
 
     ```bash
-    az acr build -t hackfest/service-tracker-ui:newversion -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/service-tracker-ui
+    az acr build -t hackfest/service-tracker-ui:newversion -r $ACRNAME --no-logs app/service-tracker-ui
     ```
 
 * Watch the pods in the namespace
@@ -226,7 +226,7 @@ We can use "pod disruption budgets" to make sure a minimum number of pods are av
 * Create a service account and role binding
 
     ```bash    
-    kubectl apply -f ~/kubernetes-hackfest/labs/best-practices/operators/sa-kube-advisor.yaml
+    kubectl apply -f labs/best-practices/operators/sa-kube-advisor.yaml
     ```
 
 * Create the pod

--- a/labs/build-application/README.md
+++ b/labs/build-application/README.md
@@ -33,7 +33,7 @@ In this lab we will build Docker containers for each of the application componen
     **NOTE: If the below role assignment fails due to permissions, we will do it the hard way and create an Image Pull Secret.**
 
     ```bash
-    sh ~/kubernetes-hackfest/labs/build-application/reg-acr.sh $RGNAME $CLUSTERNAME $ACRNAME
+    sh labs/build-application/reg-acr.sh $RGNAME $CLUSTERNAME $ACRNAME
     ```
 
     ```bash
@@ -68,7 +68,7 @@ In this lab we will build Docker containers for each of the application componen
     # Create a unique application insights name
     APPINSIGHTSNAME=appInsightshackfest$UNIQUE_SUFFIX
     # Deploy the appinsights ARM template   
-    az group deployment create --resource-group $RGNAME --template-file ~/kubernetes-hackfest/labs/build-application/app-Insights.json --parameters type=Node.js name=$APPINSIGHTSNAME regionId=eastus
+    az group deployment create --resource-group $RGNAME --template-file labs/build-application/app-Insights.json --parameters type=Node.js name=$APPINSIGHTSNAME regionId=eastus
     ```
 
     Alternatively :    
@@ -130,11 +130,11 @@ In this lab we will build Docker containers for each of the application componen
     In this step we will create a Docker container image for each of our microservices. We will use ACR Builder functionality to build and store these images in the cloud. 
 
     ```bash
-    az acr build -t hackfest/data-api:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/data-api
-    az acr build -t hackfest/flights-api:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/flights-api
-    az acr build -t hackfest/quakes-api:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/quakes-api
-    az acr build -t hackfest/weather-api:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/weather-api
-    az acr build -t hackfest/service-tracker-ui:1.0 -r $ACRNAME --no-logs ~/kubernetes-hackfest/app/service-tracker-ui
+    az acr build -t hackfest/data-api:1.0 -r $ACRNAME --no-logs app/data-api
+    az acr build -t hackfest/flights-api:1.0 -r $ACRNAME --no-logs app/flights-api
+    az acr build -t hackfest/quakes-api:1.0 -r $ACRNAME --no-logs app/quakes-api
+    az acr build -t hackfest/weather-api:1.0 -r $ACRNAME --no-logs app/weather-api
+    az acr build -t hackfest/service-tracker-ui:1.0 -r $ACRNAME --no-logs app/service-tracker-ui
     ```
 
     You can see the status of the builds by running the command below.

--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -4,152 +4,157 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
 
 ## Prerequisites
 
-* Azure Account
+- Azure Account
 
 ## Instructions
 
 1. Login to Azure Portal at http://portal.azure.com.
 2. Open the Azure Cloud Shell and choose Bash Shell (do not choose Powershell)
 
-    ![Azure Cloud Shell](img-cloud-shell.png "Azure Cloud Shell")
+   ![Azure Cloud Shell](img-cloud-shell.png "Azure Cloud Shell")
 
 3. The first time Cloud Shell is started will require you to create a storage account.
 
 4. Once your cloud shell is started, clone the workshop repo into the cloud shell environment
-    ```bash
-    git clone https://github.com/Azure/kubernetes-hackfest
-    ```
 
-    > Note: In the cloud shell, you are automatically logged into your Azure subscription.
+   ```bash
+   git clone https://github.com/Azure/kubernetes-hackfest
+   ```
+
+   > Note: In the cloud shell, you are automatically logged into your Azure subscription.
 
 5. Ensure you are using the correct Azure subscription you want to deploy AKS to.
-    ```
-    # View subscriptions
-    az account list
-    ```
-    ```
-    # Verify selected subscription
-    az account show
-    ```
 
-    ```
-    # Set correct subscription (if needed)
-    az account set --subscription <subscription_id>
+   ```
+   # View subscriptions
+   az account list
+   ```
 
-    # Verify correct subscription is now set
-    az account show
-    ```
+   ```
+   # Verify selected subscription
+   az account show
+   ```
+
+   ```
+   # Set correct subscription (if needed)
+   az account set --subscription <subscription_id>
+
+   # Verify correct subscription is now set
+   az account show
+   ```
 
 6. Create Azure Service Principal to use through the labs
 
-    ```bash
-    az ad sp create-for-rbac --skip-assignment
-    ```
-    This will return the following. !!!IMPORTANT!!! - Please copy this information down as you'll need it for labs going forward.
+   ```bash
+   az ad sp create-for-rbac --skip-assignment
+   ```
 
-    ```bash
-    "appId": "7248f250-0000-0000-0000-dbdeb8400d85",
-    "displayName": "azure-cli-2017-10-15-02-20-15",
-    "name": "http://azure-cli-2017-10-15-02-20-15",
-    "password": "77851d2c-0000-0000-0000-cb3ebc97975a",
-    "tenant": "72f988bf-0000-0000-0000-2d7cd011db47"
-    ```
+   This will return the following. !!!IMPORTANT!!! - Please copy this information down as you'll need it for labs going forward.
 
-    Set the values from above as variables **(replace <appId> and <password> with your values)**.
+   ```bash
+   "appId": "7248f250-0000-0000-0000-dbdeb8400d85",
+   "displayName": "azure-cli-2017-10-15-02-20-15",
+   "name": "http://azure-cli-2017-10-15-02-20-15",
+   "password": "77851d2c-0000-0000-0000-cb3ebc97975a",
+   "tenant": "72f988bf-0000-0000-0000-2d7cd011db47"
+   ```
 
-    DON'T MESS THIS STEP UP. REPLACE THE VALUES IN BRACKETS!!!
+   Set the values from above as variables **(replace <appId> and <password> with your values)**.
 
-    ```bash
-    # Persist for Later Sessions in Case of Timeout
-    APPID=<appId>
-    echo export APPID=$APPID >> ~/.bashrc
-    CLIENTSECRET=<password>
-    echo export CLIENTSECRET=$CLIENTSECRET >> ~/.bashrc
-    ```
+   DON'T MESS THIS STEP UP. REPLACE THE VALUES IN BRACKETS!!!
 
-7. Create a  unique identifier suffix for resources to be created in this lab.
+   ```bash
+   # Persist for Later Sessions in Case of Timeout
+   APPID=<appId>
+   echo export APPID=$APPID >> ~/.bashrc
+   CLIENTSECRET=<password>
+   echo export CLIENTSECRET=$CLIENTSECRET >> ~/.bashrc
+   ```
 
-    ```bash
-    UNIQUE_SUFFIX=$USER$RANDOM
-    # Remove Underscores and Dashes (Not Allowed in AKS and ACR Names)
-    UNIQUE_SUFFIX="${UNIQUE_SUFFIX//_}"
-    UNIQUE_SUFFIX="${UNIQUE_SUFFIX//-}"
-    # Check Unique Suffix Value (Should be No Underscores or Dashes)
-    echo $UNIQUE_SUFFIX
-    # Persist for Later Sessions in Case of Timeout
-    echo export UNIQUE_SUFFIX=$UNIQUE_SUFFIX >> ~/.bashrc
-    ```
+7. Create a unique identifier suffix for resources to be created in this lab.
 
-    *** Note this value as it will be used in the next couple labs. ***
+   ```bash
+   UNIQUE_SUFFIX=$USER$RANDOM
+   # Remove Underscores and Dashes (Not Allowed in AKS and ACR Names)
+   UNIQUE_SUFFIX="${UNIQUE_SUFFIX//_}"
+   UNIQUE_SUFFIX="${UNIQUE_SUFFIX//-}"
+   # Check Unique Suffix Value (Should be No Underscores or Dashes)
+   echo $UNIQUE_SUFFIX
+   # Persist for Later Sessions in Case of Timeout
+   echo export UNIQUE_SUFFIX=$UNIQUE_SUFFIX >> ~/.bashrc
+   ```
+
+   **_ Note this value as it will be used in the next couple labs. _**
 
 8. Create an Azure Resource Group in East US.
 
-    ```bash
-    # Set Resource Group Name using the unique suffix
-    RGNAME=aks-rg-$UNIQUE_SUFFIX
-    # Persist for Later Sessions in Case of Timeout
-    echo export RGNAME=$RGNAME >> ~/.bashrc
-    # Set Region (Location)
-    LOCATION=eastus
-    # Persist for Later Sessions in Case of Timeout
-    echo export LOCATION=eastus >> ~/.bashrc
-    # Create Resource Group
-    az group create -n $RGNAME -l $LOCATION
-    ```
+   ```bash
+   # Set Resource Group Name using the unique suffix
+   RGNAME=aks-rg-$UNIQUE_SUFFIX
+   # Persist for Later Sessions in Case of Timeout
+   echo export RGNAME=$RGNAME >> ~/.bashrc
+   # Set Region (Location)
+   LOCATION=eastus
+   # Persist for Later Sessions in Case of Timeout
+   echo export LOCATION=eastus >> ~/.bashrc
+   # Create Resource Group
+   az group create -n $RGNAME -l $LOCATION
+   ```
 
 9. Create your AKS cluster in the resource group created above with 3 nodes. We will check for a recent version of kubnernetes before proceeding. We are also including the monitoring add-on for Azure Container Insights. You will use the Service Principal information from step 5.
 
-    Use Unique CLUSTERNAME
+   Use Unique CLUSTERNAME
 
-    ```bash
-    # Set AKS Cluster Name
-    CLUSTERNAME=aks${UNIQUE_SUFFIX}
-    # Look at AKS Cluster Name for Future Reference
-    echo $CLUSTERNAME
-    # Persist for Later Sessions in Case of Timeout
-    echo export CLUSTERNAME=aks${UNIQUE_SUFFIX} >> ~/.bashrc
-    ```  
+   ```bash
+   # Set AKS Cluster Name
+   CLUSTERNAME=aks${UNIQUE_SUFFIX}
+   # Look at AKS Cluster Name for Future Reference
+   echo $CLUSTERNAME
+   # Persist for Later Sessions in Case of Timeout
+   echo export CLUSTERNAME=aks${UNIQUE_SUFFIX} >> ~/.bashrc
+   ```
 
-    Get available kubernetes versions for the region. You will likely see more recent versions in your lab.
+   Get available kubernetes versions for the region. You will likely see more recent versions in your lab.
 
-    ```bash
-    az aks get-versions -l $LOCATION --output table
+   ```bash
+   az aks get-versions -l $LOCATION --output table
 
-    KubernetesVersion    Upgrades
-    -------------------  ------------------------
-    1.14.0(preview)      None available
-    1.13.5               1.14.0(preview)
-    1.12.8               1.13.5
-    1.12.7               1.12.8, 1.13.5
-    1.11.9               1.12.7, 1.12.8
-    1.11.8               1.11.9, 1.12.7, 1.12.8
-    1.10.13              1.11.8, 1.11.9
-    1.10.12              1.10.13, 1.11.8, 1.11.9
-    1.9.11               1.10.12, 1.10.13
-    1.9.10               1.9.11, 1.10.12, 1.10.13
-    ```
+   KubernetesVersion    Upgrades
+   -------------------  ------------------------
+   1.14.0(preview)      None available
+   1.13.5               1.14.0(preview)
+   1.12.8               1.13.5
+   1.12.7               1.12.8, 1.13.5
+   1.11.9               1.12.7, 1.12.8
+   1.11.8               1.11.9, 1.12.7, 1.12.8
+   1.10.13              1.11.8, 1.11.9
+   1.10.12              1.10.13, 1.11.8, 1.11.9
+   1.9.11               1.10.12, 1.10.13
+   1.9.10               1.9.11, 1.10.12, 1.10.13
+   ```
 
-    Set the version to one with available upgrades (in this case v 1.12.8)
+   Set the version to one with available upgrades (in this case v 1.12.8)
 
-    ```bash
-    K8SVERSION=1.13.5
-    ```
+   ```bash
+   K8SVERSION=1.13.5
+   ```
 
-    > The below command can take 10-20 minutes to run as it is creating the AKS cluster. Please be PATIENT and grab a coffee...
+   > The below command can take 10-20 minutes to run as it is creating the AKS cluster. Please be PATIENT and grab a coffee...
 
-    ```bash
-    # Create AKS Cluster
-    az aks create -n $CLUSTERNAME -g $RGNAME \
-    --kubernetes-version $K8SVERSION \
-    --service-principal $APPID \
-    --client-secret $CLIENTSECRET \
-    --generate-ssh-keys -l $LOCATION \
-    --node-count 3 \
-    --enable-addons monitoring \
-    --no-wait
-    ```
+   ```bash
+   # Create AKS Cluster
+   az aks create -n $CLUSTERNAME -g $RGNAME \
+   --kubernetes-version $K8SVERSION \
+   --service-principal $APPID \
+   --client-secret $CLIENTSECRET \
+   --generate-ssh-keys -l $LOCATION \
+   --node-count 3 \
+   --enable-addons monitoring \
+   --no-wait
+   ```
 
 10. Verify your cluster status. The `ProvisioningState` should be `Succeeded`
+
     ```bash
     az aks list -o table
     ```
@@ -168,34 +173,34 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
 
 12. Verify you have API access to your new AKS cluster
 
-      > Note: It can take 5 minutes for your nodes to appear and be in READY state. You can run `watch kubectl get nodes` to monitor status.
+    > Note: It can take 5 minutes for your nodes to appear and be in READY state. You can run `watch kubectl get nodes` to monitor status.
 
-     ```bash
-     kubectl get nodes
-     ```
-     
-     ```bash
-     NAME                       STATUS   ROLES   AGE     VERSION
-     aks-nodepool1-14089323-0   Ready    agent   113s    v1.12.8
-     aks-nodepool1-14089323-1   Ready    agent   2m59s   v1.12.8
-     aks-nodepool1-14089323-2   Ready    agent   2m1s    v1.12.8     
-     ```
- 
-     To see more details about your cluster:
+    ```bash
+    kubectl get nodes
+    ```
 
-     ```bash
-     kubectl cluster-info
-     ```
+    ```bash
+    NAME                       STATUS   ROLES   AGE     VERSION
+    aks-nodepool1-14089323-0   Ready    agent   113s    v1.12.8
+    aks-nodepool1-14089323-1   Ready    agent   2m59s   v1.12.8
+    aks-nodepool1-14089323-2   Ready    agent   2m1s    v1.12.8
+    ```
 
-     ```bash
+    To see more details about your cluster:
+
+    ```bash
+    kubectl cluster-info
+    ```
+
+    ```bash
     Kubernetes master is running at https://aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io:443
     Heapster is running at https://aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io:443/api/v1/namespaces/kube-system/services/heapster/proxy
     CoreDNS is running at https://aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io:443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
     kubernetes-dashboard is running at https://aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io:443/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy
     Metrics-server is running at https://aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io:443/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
-     ```
+    ```
 
-     You should now have a Kubernetes cluster running with 3 nodes. You do not see the master servers for the cluster because these are managed by Microsoft. The Control Plane services which manage the Kubernetes cluster such as scheduling, API access, configuration data store and object controllers are all provided as services to the nodes.
+    You should now have a Kubernetes cluster running with 3 nodes. You do not see the master servers for the cluster because these are managed by Microsoft. The Control Plane services which manage the Kubernetes cluster such as scheduling, API access, configuration data store and object controllers are all provided as services to the nodes.
 
 ## Namespaces Setup
 
@@ -207,96 +212,93 @@ This lab creates namespaces that reflect a representative example of an organiza
    cd kubernetes-hackfest
    ```
 
-
 2. Create three namespaces
 
-    ```bash
-    # Create namespaces
-    kubectl apply -f labs/create-aks-cluster/create-namespaces.yaml
+   ```bash
+   # Create namespaces
+   kubectl apply -f labs/create-aks-cluster/create-namespaces.yaml
 
-    # Look at namespaces
-    kubectl get ns
-    ```
+   # Look at namespaces
+   kubectl get ns
+   ```
 
 3. Assign CPU, memory and storage limits to namespaces
 
-    ```bash
-    # Create namespace limits
-    kubectl apply -f labs/create-aks-cluster/namespace-limitranges.yaml
+   ```bash
+   # Create namespace limits
+   kubectl apply -f labs/create-aks-cluster/namespace-limitranges.yaml
 
-    # Get list of namespaces and drill into one
-    kubectl get ns
-    kubectl describe 
-    ```
+   # Get list of namespaces and drill into one
+   kubectl get ns
+   kubectl describe
+   ```
 
 4. Assign CPU, Memory and Storage Quotas to Namespaces
 
-    ```bash
-    # Create namespace quotas
-    kubectl apply -f labs/create-aks-cluster/namespace-quotas.yaml
+   ```bash
+   # Create namespace quotas
+   kubectl apply -f labs/create-aks-cluster/namespace-quotas.yaml
 
-    # Get list of namespaces and drill into one
-    kubectl get ns
-    kubectl describe ns dev
-    ```
+   # Get list of namespaces and drill into one
+   kubectl get ns
+   kubectl describe ns dev
+   ```
 
 5. Test out Limits and Quotas in **dev** Namespace
 
-    ```bash
-    # Test Limits - Forbidden due to assignment of CPU too low
-    kubectl run nginx-limittest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=100m,memory=256Mi' -n dev
+   ```bash
+   # Test Limits - Forbidden due to assignment of CPU too low
+   kubectl run nginx-limittest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=100m,memory=256Mi' -n dev
 
-    # Test Limits - Pass due to automatic assignment within limits via defaults
-    kubectl run nginx-limittest --image=nginx --restart=Never --replicas=1 --port=80 -n dev
-    
-    # Check running pod and dev Namespace Allocations
-    kubectl get po -n dev
-    kubectl describe ns dev
-    
-    # Test Quotas - Forbidden due to memory quota exceeded
-    kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=1Gi' -n dev
-    
-    # Test Quotas - Pass due to memory within quota
-    kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=512Mi' -n dev
-    
-    # Check running pod and dev Namespace Allocations
-    kubectl get po -n 
-    kubectl describe n
-    ```
+   # Test Limits - Pass due to automatic assignment within limits via defaults
+   kubectl run nginx-limittest --image=nginx --restart=Never --replicas=1 --port=80 -n dev
+
+   # Check running pod and dev Namespace Allocations
+   kubectl get po -n dev
+   kubectl describe ns dev
+
+   # Test Quotas - Forbidden due to memory quota exceeded
+   kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=1Gi' -n dev
+
+   # Test Quotas - Pass due to memory within quota
+   kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=512Mi' -n dev
+
+   # Check running pod and dev Namespace Allocations
+   kubectl get po -n
+   kubectl describe n
+   ```
 
 6. Clean up limits, quotas, pods
 
-    ```bash
-    kubectl delete -f labs/create-aks-cluster/namespace-limitranges.yaml
-    kubectl delete -f labs/create-aks-cluster/namespace-quotas.yaml
-    kubectl delete po nginx-limittest nginx-quotatest -n dev
+   ```bash
+   kubectl delete -f labs/create-aks-cluster/namespace-limitranges.yaml
+   kubectl delete -f labs/create-aks-cluster/namespace-quotas.yaml
+   kubectl delete po nginx-limittest nginx-quotatest -n dev
 
-    kubectl describe ns dev
-    kubectl describe ns uat
-    kubectl describe ns prod
-    ```
+   kubectl describe ns dev
+   kubectl describe ns uat
+   kubectl describe ns prod
+   ```
 
 7. Create namespace for our application. This will be used in subsequent labs.
 
-    ```bash
-    kubectl create ns hackfest
-    ```
-
+   ```bash
+   kubectl create ns hackfest
+   ```
 
 ## Troubleshooting / Debugging
 
-* The limits and quotas of a namespace can be found via the **kubectl describe ns <...>** command. You will also be able to see current allocations.
-* If pods are not deploying then check to make sure that CPU, Memory and Storage amounts are within the limits and do not exceed the overall quota of the namespace.
+- The limits and quotas of a namespace can be found via the **kubectl describe ns <...>** command. You will also be able to see current allocations.
+- If pods are not deploying then check to make sure that CPU, Memory and Storage amounts are within the limits and do not exceed the overall quota of the namespace.
 
 ## Docs / References
 
-* [Troubleshoot Kubernetes Clusters](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-cluster)
-* [Kubernetes Namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
-* [Default CPU Requests and Limits for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
-* [Configure Min and Max CPU Constraints for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
-* [Configure Memory and CPU Quotas for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
-* [Use Ansible to deploy AKS](https://docs.microsoft.com/en-us/azure/ansible/ansible-create-configure-aks?toc=%2Fen-us%2Fazure%2Faks%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json)
-* [Use Terraform to deploy AKS](https://docs.microsoft.com/en-us/azure/terraform/terraform-create-k8s-cluster-with-tf-and-aks?toc=%2Fen-us%2Fazure%2Faks%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json)
-
+- [Troubleshoot Kubernetes Clusters](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-cluster)
+- [Kubernetes Namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+- [Default CPU Requests and Limits for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
+- [Configure Min and Max CPU Constraints for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
+- [Configure Memory and CPU Quotas for a Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
+- [Use Ansible to deploy AKS](https://docs.microsoft.com/en-us/azure/ansible/ansible-create-configure-aks?toc=%2Fen-us%2Fazure%2Faks%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json)
+- [Use Terraform to deploy AKS](https://docs.microsoft.com/en-us/azure/terraform/terraform-create-k8s-cluster-with-tf-and-aks?toc=%2Fen-us%2Fazure%2Faks%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json)
 
 #### Next Lab: [Build Application Components and Prerequisites](../build-application/README.md)

--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -201,39 +201,46 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
 
 This lab creates namespaces that reflect a representative example of an organization's environments. In this case dev, uat and prod. We will also apply the appopriate permissions, limits and resource quotas to each of the namespaces.
 
-1. Create three namespaces
+1. Navigate to the directory of the cloned repository
+
+   ```bash
+   cd kubernetes-hackfest
+   ```
+
+
+2. Create three namespaces
 
     ```bash
     # Create namespaces
-    kubectl apply -f ~/kubernetes-hackfest/labs/create-aks-cluster/create-namespaces.yaml
+    kubectl apply -f labs/create-aks-cluster/create-namespaces.yaml
 
     # Look at namespaces
     kubectl get ns
     ```
 
-2. Assign CPU, memory and storage limits to namespaces
+3. Assign CPU, memory and storage limits to namespaces
 
     ```bash
     # Create namespace limits
-    kubectl apply -f ~/kubernetes-hackfest/labs/create-aks-cluster/namespace-limitranges.yaml
+    kubectl apply -f labs/create-aks-cluster/namespace-limitranges.yaml
 
     # Get list of namespaces and drill into one
     kubectl get ns
-    kubectl describe ns uat
+    kubectl describe 
     ```
 
-3. Assign CPU, Memory and Storage Quotas to Namespaces
+4. Assign CPU, Memory and Storage Quotas to Namespaces
 
     ```bash
     # Create namespace quotas
-    kubectl apply -f ~/kubernetes-hackfest/labs/create-aks-cluster/namespace-quotas.yaml
+    kubectl apply -f labs/create-aks-cluster/namespace-quotas.yaml
 
     # Get list of namespaces and drill into one
     kubectl get ns
     kubectl describe ns dev
     ```
 
-4. Test out Limits and Quotas in **dev** Namespace
+5. Test out Limits and Quotas in **dev** Namespace
 
     ```bash
     # Test Limits - Forbidden due to assignment of CPU too low
@@ -253,15 +260,15 @@ This lab creates namespaces that reflect a representative example of an organiza
     kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=512Mi' -n dev
     
     # Check running pod and dev Namespace Allocations
-    kubectl get po -n dev
-    kubectl describe ns dev
+    kubectl get po -n 
+    kubectl describe n
     ```
 
-5. Clean up limits, quotas, pods
+6. Clean up limits, quotas, pods
 
     ```bash
-    kubectl delete -f ~/kubernetes-hackfest/labs/create-aks-cluster/namespace-limitranges.yaml
-    kubectl delete -f ~/kubernetes-hackfest/labs/create-aks-cluster/namespace-quotas.yaml
+    kubectl delete -f labs/create-aks-cluster/namespace-limitranges.yaml
+    kubectl delete -f labs/create-aks-cluster/namespace-quotas.yaml
     kubectl delete po nginx-limittest nginx-quotatest -n dev
 
     kubectl describe ns dev
@@ -269,7 +276,7 @@ This lab creates namespaces that reflect a representative example of an organiza
     kubectl describe ns prod
     ```
 
-6. Create namespace for our application. This will be used in subsequent labs.
+7. Create namespace for our application. This will be used in subsequent labs.
 
     ```bash
     kubectl create ns hackfest

--- a/labs/helm-setup-deploy/README.md
+++ b/labs/helm-setup-deploy/README.md
@@ -17,7 +17,7 @@ In this lab we will setup Helm in our AKS cluster and deploy our application wit
     * Initialize Helm and Tiller:
 
         ```bash
-        kubectl apply -f ~/kubernetes-hackfest/labs/helm-setup-deploy/rbac-config.yaml
+        kubectl apply -f labs/helm-setup-deploy/rbac-config.yaml
         helm init --service-account tiller --upgrade
         ```
 
@@ -139,11 +139,11 @@ In this lab we will setup Helm in our AKS cluster and deploy our application wit
     ```bash
     # Application charts
 
-    helm upgrade --install data-api ~/kubernetes-hackfest/charts/data-api --namespace hackfest
-    helm upgrade --install quakes-api ~/kubernetes-hackfest/charts/quakes-api --namespace hackfest
-    helm upgrade --install weather-api ~/kubernetes-hackfest/charts/weather-api --namespace hackfest
-    helm upgrade --install flights-api ~/kubernetes-hackfest/charts/flights-api --namespace hackfest
-    helm upgrade --install service-tracker-ui ~/kubernetes-hackfest/charts/service-tracker-ui --namespace hackfest
+    helm upgrade --install data-api charts/data-api --namespace hackfest
+    helm upgrade --install quakes-api charts/quakes-api --namespace hackfest
+    helm upgrade --install weather-api charts/weather-api --namespace hackfest
+    helm upgrade --install flights-api charts/flights-api --namespace hackfest
+    helm upgrade --install service-tracker-ui charts/service-tracker-ui --namespace hackfest
     ```
 
 5. Initialize application

--- a/labs/monitoring-logging/prometheus-grafana/README.md
+++ b/labs/monitoring-logging/prometheus-grafana/README.md
@@ -17,7 +17,7 @@ This lab will walkthrough using the Core OS Prometheus Operator to add Monitorin
 
     ```bash
     # Switch to the lab directory in Azure Cloud Shell
-    cd ~/kubernetes-hackfest/labs/monitoring-logging/prometheus-grafana
+    cd labs/monitoring-logging/prometheus-grafana
     ```
 
     ```bash

--- a/labs/networking/ingress/README.md
+++ b/labs/networking/ingress/README.md
@@ -26,7 +26,7 @@ An ingress controller is a piece of software that provides reverse proxy, config
 
     ```bash
     # update chart to install service again as ClusterIP
-    helm upgrade service-tracker-ui ~/kubernetes-hackfest/charts/service-tracker-ui --set service.type=ClusterIP
+    helm upgrade service-tracker-ui charts/service-tracker-ui --set service.type=ClusterIP
     ```
 
 2. Create the NGINX ingress controller
@@ -58,12 +58,12 @@ An ingress controller is a piece of software that provides reverse proxy, config
     * Set permissions on the script
 
         ```bash
-        chmod +x ~/kubernetes-hackfest/labs/networking/ingress/configure-publicip-dns.sh
+        chmod +x labs/networking/ingress/configure-publicip-dns.sh
         ```
 
     * Execute the script
         ```
-        ~/kubernetes-hackfest/labs/networking/ingress/configure-publicip-dns.sh
+        labs/networking/ingress/configure-publicip-dns.sh
         ```
 
     * Note the new DNS name for your public IP. It should be something like `brian13270.eastus.cloudapp.azure.com`. You can look it up in the portal in the "MC" resource group for your cluster. 
@@ -77,8 +77,8 @@ An ingress controller is a piece of software that provides reverse proxy, config
 
     ```bash
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-    -out ~/kubernetes-hackfest/labs/networking/ingress/aks-ingress-tls.crt \
-    -keyout ~/kubernetes-hackfest/labs/networking/ingress/aks-ingress-tls.key \
+    -out labs/networking/ingress/aks-ingress-tls.crt \
+    -keyout labs/networking/ingress/aks-ingress-tls.key \
     -subj "/CN=brian13270.eastus.cloudapp.azure.com/O=aks-ingress-tls"
     ```
 
@@ -88,8 +88,8 @@ An ingress controller is a piece of software that provides reverse proxy, config
 
     ```bash
     kubectl create secret tls aks-ingress-tls \
-    --key ~/kubernetes-hackfest/labs/networking/ingress/aks-ingress-tls.key \
-    --cert ~/kubernetes-hackfest/labs/networking/ingress/aks-ingress-tls.crt -n hackfest
+    --key labs/networking/ingress/aks-ingress-tls.key \
+    --cert labs/networking/ingress/aks-ingress-tls.crt -n hackfest
     ```
 
 6. Create an ingress route
@@ -99,7 +99,7 @@ An ingress controller is a piece of software that provides reverse proxy, config
     * Apply
 
         ```bash
-        kubectl apply -f ~/kubernetes-hackfest/labs/networking/ingress/service-tracker-ingress.yaml -n hackfest
+        kubectl apply -f labs/networking/ingress/service-tracker-ingress.yaml -n hackfest
         ```
 
 7. Test configuration

--- a/labs/networking/ingress/lets-encrypt.md.md
+++ b/labs/networking/ingress/lets-encrypt.md.md
@@ -38,10 +38,10 @@ This lab is about setting up the Ingress Controller and configuring the differen
 
     ```bash
     # first, set permissions on script
-    chmod +x ~/kubernetes-hackfest/labs/networking/ingress/configure-publicip-dns.sh
+    chmod +x labs/networking/ingress/configure-publicip-dns.sh
 
     # do it
-    ~/kubernetes-hackfest/labs/networking/ingress/configure-publicip-dns.sh
+    labs/networking/ingress/configure-publicip-dns.sh
     ```
 
 4. Install Cert Mgr with RBAC
@@ -53,7 +53,7 @@ This lab is about setting up the Ingress Controller and configuring the differen
 5. Create CA Cluster Issuer
 
     ```bash
-    kubectl apply -f ~/kubernetes-hackfest/labs/networking/ingress/cluster-issuer.yaml
+    kubectl apply -f labs/networking/ingress/cluster-issuer.yaml
     ```
 
 6. Create Cluster Certificate
@@ -64,7 +64,7 @@ This lab is about setting up the Ingress Controller and configuring the differen
 
     ```bash
     # Make sure DNSNAME Matches value used above
-    kubectl apply -f ~/kubernetes-hackfest/labs/networking/ingress/certificate.yaml
+    kubectl apply -f labs/networking/ingress/certificate.yaml
     ```
 
 7. Apply Ingress Rules
@@ -72,7 +72,7 @@ This lab is about setting up the Ingress Controller and configuring the differen
 
     ```bash
     # Apply Ingress Routes
-    kubectl apply -f ~/kubernetes-hackfest/labs/networking/ingress/app-ingress.yaml
+    kubectl apply -f labs/networking/ingress/app-ingress.yaml
 
     # Check Ingress Route & Endpoints
     kubectl get ingress

--- a/labs/scaling/README.md
+++ b/labs/scaling/README.md
@@ -32,7 +32,7 @@ The Kubernetes Horizontal Pod Autoscaler (HPA) automatically scales the number o
 2. Deploy the hpa resource
 
     ```bash
-    kubectl apply -f ~/kubernetes-hackfest/labs/scaling/hpa.yaml -n hackfest
+    kubectl apply -f labs/scaling/hpa.yaml -n hackfest
     ```
 
 3. Validate the number of pods is now 5 which is our `minReplicas` set with the HPA

--- a/labs/security/secure-tiller/README.md
+++ b/labs/security/secure-tiller/README.md
@@ -8,7 +8,7 @@ This lab walks through how to secure tiller in a single namespace to restrict ac
 
     ```bash
     # Move to the lab directory
-    cd ~/kubernetes-hackfest/labs/security/secure-tiller/
+    cd labs/security/secure-tiller/
 
     # Create kubeconfig file for tiller Service Account (Useful for DevOps)
     chmod a+x tiller-namespace-setup.sh


### PR DESCRIPTION
As discussed in #118, the absolute paths (all starting with `~/kubernetes-hackfest/...`) only work, when the workshop participant cloned the GitHub repository into the `$HOME` directory. When using Azure Cloud Shell, this might be the case, but when trying to complete the lab on your own machine, this is very unlikely.

This change makes it way more flexible to work with the labs, as the only additional step a user has to do is navigating to the directory of the cloned repo. Completely independent of its location and folder name.