### PR TITLE
Update go version

### DIFF
--- a/app/sample-go/Dockerfile
+++ b/app/sample-go/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.10.1 AS build-env
+FROM golang:1.13.1 AS build-env
 WORKDIR /go/src/app
 ADD . .
 RUN go get -d -v


### PR DESCRIPTION
update go version in order to see v2 visibility of xxhash and not receive an error ('cannot find package "github.com/cespare/xxhash/v2" in any of:...')
--reference for go version requirement from xxhash: https://github.com/cespare/xxhash/commit/997e1685cae39ce5a9573990e7fabe3e796898a0