### PR TITLE
Kubernetes Version Update and helm 3 note

### DIFF
--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -119,24 +119,26 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
    ```bash
    az aks get-versions -l $LOCATION --output table
 
-   KubernetesVersion    Upgrades
-   -------------------  ------------------------
-   1.14.0(preview)      None available
-   1.13.5               1.14.0(preview)
-   1.12.8               1.13.5
-   1.12.7               1.12.8, 1.13.5
-   1.11.9               1.12.7, 1.12.8
-   1.11.8               1.11.9, 1.12.7, 1.12.8
-   1.10.13              1.11.8, 1.11.9
-   1.10.12              1.10.13, 1.11.8, 1.11.9
-   1.9.11               1.10.12, 1.10.13
-   1.9.10               1.9.11, 1.10.12, 1.10.13
+    KubernetesVersion    Upgrades
+    -------------------  ----------------------------------------
+    1.15.5(preview)      None available
+    1.15.4(preview)      1.15.5(preview)
+    1.14.8               1.15.4(preview), 1.15.5(preview)
+    1.14.7               1.14.8, 1.15.4(preview), 1.15.5(preview)
+    1.13.12              1.14.7, 1.14.8
+    1.13.11              1.13.12, 1.14.7, 1.14.8
+    1.12.8               1.13.11, 1.13.12
+    1.12.7               1.12.8, 1.13.11, 1.13.12
+    1.11.10              1.12.7, 1.12.8
+    1.11.9               1.11.10, 1.12.7, 1.12.8
+    1.10.13              1.11.9, 1.11.10
+    1.10.12              1.10.13, 1.11.9, 1.11.10
    ```
 
-   Set the version to one with available upgrades (in this case v 1.12.8)
+   Set the version to one with available upgrades (in this case v 1.13.12)
 
    ```bash
-   K8SVERSION=1.13.5
+   K8SVERSION=1.13.12
    ```
 
    > The below command can take 10-20 minutes to run as it is creating the AKS cluster. Please be PATIENT and grab a coffee...
@@ -162,7 +164,7 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
     ```bash
     Name             Location    ResourceGroup            KubernetesVersion    ProvisioningState    Fqdn
     ---------------  ----------  -----------------------  -------------------  -------------------  ----------------------------------------------------------------
-    aksstephen14260  eastus      aks-rg-stephen14260      1.12.8               Succeeded            aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io
+    aksstephen14260  eastus      aks-rg-stephen14260      1.13.13              Succeeded            aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io
     ```
 
 11. Get the Kubernetes config files for your new AKS cluster
@@ -181,9 +183,9 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
 
     ```bash
     NAME                       STATUS   ROLES   AGE     VERSION
-    aks-nodepool1-14089323-0   Ready    agent   113s    v1.12.8
-    aks-nodepool1-14089323-1   Ready    agent   2m59s   v1.12.8
-    aks-nodepool1-14089323-2   Ready    agent   2m1s    v1.12.8
+    aks-nodepool1-14089323-0   Ready    agent   113s    v1.13.12
+    aks-nodepool1-14089323-1   Ready    agent   2m59s   v1.13.12
+    aks-nodepool1-14089323-2   Ready    agent   2m1s    v1.13.12
     ```
 
     To see more details about your cluster:
@@ -230,7 +232,7 @@ This lab creates namespaces that reflect a representative example of an organiza
 
    # Get list of namespaces and drill into one
    kubectl get ns
-   kubectl describe
+   kubectl describe ns <ns-name>
    ```
 
 4. Assign CPU, Memory and Storage Quotas to Namespaces
@@ -264,8 +266,8 @@ This lab creates namespaces that reflect a representative example of an organiza
    kubectl run nginx-quotatest --image=nginx --restart=Never --replicas=1 --port=80 --requests='cpu=500m,memory=512Mi' -n dev
 
    # Check running pod and dev Namespace Allocations
-   kubectl get po -n
-   kubectl describe n
+   kubectl get po -n dev
+   kubectl describe ns dev
    ```
 
 6. Clean up limits, quotas, pods

--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -61,15 +61,17 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
 
    Set the values from above as variables **(replace <appId> and <password> with your values)**.
 
-   DON'T MESS THIS STEP UP. REPLACE THE VALUES IN BRACKETS!!!
+    >**Warning:** Several of the following steps have you echo values to your .bashrc file. This is done so that you can get those values back if your session reconnects. You will want to remember to clean these up at the end of the training, in particular if you're running on your own, or your company's, subscription.
 
-   ```bash
-   # Persist for Later Sessions in Case of Timeout
-   APPID=<appId>
-   echo export APPID=$APPID >> ~/.bashrc
-   CLIENTSECRET=<password>
-   echo export CLIENTSECRET=$CLIENTSECRET >> ~/.bashrc
-   ```
+    DON'T MESS THIS STEP UP. REPLACE THE VALUES IN BRACKETS!!!
+
+    ```bash
+    # Persist for Later Sessions in Case of Timeout
+    APPID=<appId>
+    echo export APPID=$APPID >> ~/.bashrc
+    CLIENTSECRET=<password>
+    echo export CLIENTSECRET=$CLIENTSECRET >> ~/.bashrc
+    ```
 
 7. Create a unique identifier suffix for resources to be created in this lab.
 

--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -166,7 +166,7 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
     ```bash
     Name             Location    ResourceGroup            KubernetesVersion    ProvisioningState    Fqdn
     ---------------  ----------  -----------------------  -------------------  -------------------  ----------------------------------------------------------------
-    aksstephen14260  eastus      aks-rg-stephen14260      1.13.13              Succeeded            aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io
+    aksstephen14260  eastus      aks-rg-stephen14260      1.13.12              Succeeded            aksstephen-aks-rg-stephen14-62afe9-9aa48ae4.hcp.eastus.azmk8s.io
     ```
 
 11. Get the Kubernetes config files for your new AKS cluster

--- a/labs/helm-setup-deploy/README.md
+++ b/labs/helm-setup-deploy/README.md
@@ -11,7 +11,7 @@ In this lab we will setup Helm in our AKS cluster and deploy our application wit
 
 ## Instructions
 
->Note: Step 1 'Initialize Helm' below is only required if you're using a Helm version below version Helm 3. The Azure Cloud Shell now defaults to Helm 3. As of Helm 3 the 'Tiller' pod is not longer required, so the RBAC setup that follows is no longer needed. Run the following to confirm:
+>Note: Step 1 'Initialize Helm' below is only required if you're using a Helm version below version Helm 3. The Azure Cloud Shell now defaults to Helm 3. As of Helm 3 the 'Tiller' pod is no longer required, so the RBAC setup that follows is no longer needed. Run the following to confirm:
 ```bash
 helm version
 ```

--- a/labs/helm-setup-deploy/README.md
+++ b/labs/helm-setup-deploy/README.md
@@ -11,6 +11,11 @@ In this lab we will setup Helm in our AKS cluster and deploy our application wit
 
 ## Instructions
 
+>Note: Step 1 'Initialize Helm' below is only required if you're using a Helm version below version Helm 3. The Azure Cloud Shell now defaults to Helm 3. As of Helm 3 the 'Tiller' pod is not longer required, so the RBAC setup that follows is no longer needed. Run the following to confirm:
+```bash
+helm version
+```
+
 1. Initialize Helm
 
     Helm helps you manage Kubernetes applications — Helm Charts helps you define, install, and upgrade even the most complex Kubernetes application. Helm has a CLI component and a server side component called Tiller. 

--- a/labs/helm-setup-deploy/README.md
+++ b/labs/helm-setup-deploy/README.md
@@ -11,7 +11,7 @@ In this lab we will setup Helm in our AKS cluster and deploy our application wit
 
 ## Instructions
 
->Note: Step 1 'Initialize Helm' below is only required if you're using a Helm version below version Helm 3. The Azure Cloud Shell now defaults to Helm 3. As of Helm 3 the 'Tiller' pod is no longer required, so the RBAC setup that follows is no longer needed. Run the following to confirm:
+>Note: Step 1 'Initialize Helm' below is only required if you're using a Helm version below version 3. The Azure Cloud Shell now defaults to Helm 3. As of Helm 3 the 'Tiller' pod is no longer required, so the RBAC setup that follows is no longer needed. Run the following to confirm:
 ```bash
 helm version
 ```


### PR DESCRIPTION
The previously noted Kubernetes version is no longer supported, so retested the lab with a more recent version (1.13.12) and then updated the AKS cluster creation lab. Also added a note recommending users cleanup .bashrc at the end of the training. Finally, I noted the update to helm 3 and that users on helm 3 can skip the helm rbac and helm init steps.