### PR TITLE
Added note that users on helm 3 can skip step 1

### DIFF
--- a/labs/monitoring-logging/prometheus-grafana/README.md
+++ b/labs/monitoring-logging/prometheus-grafana/README.md
@@ -13,6 +13,8 @@ This lab will walkthrough using the Core OS Prometheus Operator to add Monitorin
 
 ## Instructions
 
+>**Note:** If your using Helm 3 you can skip step 1 below, as Tiller is not used and no Tiller RBAC will be needed.
+
 1. Configure and Setup Helm to Deploy Prometheus Operator
 
     ```bash


### PR DESCRIPTION
Users on Helm 3 can skip the helm rbac and tiller init steps for the prometheus lab.