### PR TITLE
Update README.md

### DIFF
--- a/labs/create-aks-cluster/README.md
+++ b/labs/create-aks-cluster/README.md
@@ -132,7 +132,7 @@ In this lab we will create our Azure Kubernetes Services (AKS) distributed compu
    1.18.17              1.18.19, 1.19.9, 1.19.11
    ```
 
-   For this lab we'll use 1.18.10
+   For this lab we'll use 1.20.7
 
    ```bash
    K8SVERSION=1.20.7


### PR DESCRIPTION
incorrect version matching, text says 1.18.10 which is an unsupported version currently [October 2021]:

KubernetesVersion    Upgrades
-------------------  -----------------------
1.21.2               None available
1.21.1               1.21.2
1.20.9               1.21.1, 1.21.2
1.20.7               1.20.9, 1.21.1, 1.21.2
1.19.13              1.20.7, 1.20.9
1.19.11              1.19.13, 1.20.7, 1.20.9